### PR TITLE
Make it possible to also set usergroup rank when register a new user

### DIFF
--- a/core/components/login/processors/register.php
+++ b/core/components/login/processors/register.php
@@ -229,7 +229,8 @@ class LoginRegisterProcessor extends LoginProcessor {
                 } else {
                     $member->set('role',1);
                 }
-                $member->set('rank',$userGroupMeta[2]);
+                $rank = !empty($userGroupMeta[2]) ? $userGroupMeta[2] : 0;
+                $member->set('rank',$rank);
                 $this->user->addMany($member,'UserGroupMembers');
                 $added[] = $userGroup->get('name');
             }


### PR DESCRIPTION
Makes it possible to also set usergroup rank when register new user:
```
[[!Register?
    &usergroups=`Administrator:Member:0,anusergroup:Super User:1,someusergroup:Super User:2`
```
![register2](https://user-images.githubusercontent.com/346269/44318337-3912ac80-a3ea-11e8-87d3-6b47c48b3a2f.png)